### PR TITLE
fixed redefinition of typedef ‘lwan_t’

### DIFF
--- a/lwan.h
+++ b/lwan.h
@@ -72,7 +72,6 @@
 typedef struct lwan_request_t_		lwan_request_t;
 typedef struct lwan_response_t_		lwan_response_t;
 typedef struct lwan_url_map_t_		lwan_url_map_t;
-typedef struct lwan_t_			lwan_t;
 typedef struct lwan_thread_t_		lwan_thread_t;
 typedef struct lwan_key_value_t_	lwan_key_value_t;
 typedef struct lwan_handler_t_		lwan_handler_t;


### PR DESCRIPTION
lwan.h:75: error: redefinition of typedef ‘lwan_t’
lwan-status.h:23: note: previous declaration of ‘lwan_t’ was here
make[2]: **\* [CMakeFiles/lwan-common.dir/int-to-str.c.o] Error 1
make[1]: **\* [CMakeFiles/lwan-common.dir/all] Error 2
