### PR TITLE
Removing some "slops"

### DIFF
--- a/common/lwan-coro.c
+++ b/common/lwan-coro.c
@@ -45,14 +45,14 @@ struct coro_t_ {
     coro_context_t context;
     int yield_value;
 
+#if !defined(NDEBUG) && defined(USE_VALGRIND)
+    int vg_stack_id;
+#endif
+
     coro_defer_t *defer;
     void *data;
 
     bool ended;
-
-#if !defined(NDEBUG) && defined(USE_VALGRIND)
-    int vg_stack_id;
-#endif
 };
 
 static void _coro_entry_point(coro_t *data, coro_function_t func);

--- a/common/lwan.h
+++ b/common/lwan.h
@@ -167,10 +167,10 @@ struct lwan_connection_t_ {
 
 struct lwan_request_t_ {
     lwan_request_flags_t flags;
+    int fd;
     lwan_value_t url;
     lwan_value_t original_url;
     lwan_connection_t *conn;
-    int fd;
 
     struct {
         lwan_key_value_t *base;
@@ -214,8 +214,8 @@ struct lwan_thread_t_ {
         time_t last;
     } date;
 
-    int id;
     pthread_t self;
+    int id;
     int epoll_fd;
 };
 


### PR DESCRIPTION
Just re-ordering some field inside structures to avoid extra memory
required by memory-alignment.
