### PR TITLE
Make lwan compilable on Ubuntu 12.04

### DIFF
--- a/freegeoip/CMakeLists.txt
+++ b/freegeoip/CMakeLists.txt
@@ -6,10 +6,10 @@ add_executable(freegeoip
 )
 
 target_link_libraries(freegeoip
-	${CMAKE_THREAD_LIBS_INIT}
 	${MALLOC_LIB}
-	${ZLIB_LIBRARIES}
 	${SQLITE_LIBRARIES}
 	lwan-common
 	dl
+	${ZLIB_LIBRARIES}
+	${CMAKE_THREAD_LIBS_INIT}
 )

--- a/freegeoip/freegeoip.c
+++ b/freegeoip/freegeoip.c
@@ -421,7 +421,7 @@ main(void)
                                  SQLITE_OPEN_READONLY, NULL);
     if (result != SQLITE_OK)
         lwan_status_critical("Could not open database: %s",
-                    sqlite3_errstr(result));
+                    sqlite3_errmsg(db));
     cache = cache_create(create_ipinfo, destroy_ipinfo, NULL, 10);
 
 #if QUERIES_PER_HOUR != 0

--- a/lwan/CMakeLists.txt
+++ b/lwan/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_executable(lwan main.c)
 
 target_link_libraries(lwan
-	${CMAKE_THREAD_LIBS_INIT}
 	${MALLOC_LIB}
-	${ZLIB_LIBRARIES}
 	lwan-common
 	dl
+	${ZLIB_LIBRARIES}
+	${CMAKE_THREAD_LIBS_INIT}
 )
 


### PR DESCRIPTION
Changes as below:
- Modify the library order to as to ensure that pthread-related
  `undefined reference`s are all accounted for. Similarly, move
  zlib references to the end. This was an issue for both `lwan`
  and `freegeoip` binaries, so fix only those.
- `sqlite3_errstr` remains undefined even after rearranging the
  order of library linking. This could be an issue with `v3.8.3` of
  sqlite3 I am using, but not completely sure. Modifying it to
  `sqlite3_errmsg` works in a backward-compatible manner.

The system that I am working with looks like follows:

``` shell
vaibhav@sahadev:~/lwan|master⇒  uname -a
Linux sahadev 3.8.0-29-generic #42~precise1-Ubuntu SMP Wed Aug 14 16:19:23 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
vaibhav@sahadev:~/lwan|master⇒  lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 12.04.3 LTS
Release:    12.04
Codename:   precise
```
