### PR TITLE
Fix ipv6

### DIFF
--- a/common/lwan-socket.c
+++ b/common/lwan-socket.c
@@ -188,7 +188,7 @@ _setup_socket_normally(lwan_t *l)
 
     char host_buf[NI_MAXHOST], serv_buf[NI_MAXSERV];
     ret = getnameinfo(a->ai_addr, a->ai_addrlen, host_buf, sizeof(host_buf),
-                      serv_buf, sizeof(serv_buf), NI_NUMERICSERV);
+                      serv_buf, sizeof(serv_buf), NI_NUMERICHOST | NI_NUMERICSERV);
     if (ret)
         lwan_status_critical("getnameinfo: %s", gai_strerror(ret));
 


### PR DESCRIPTION
I like the new listener line but we can't pass in the brackets from the IPv6 addresses.

I've also changed the listening message to always show numeric IP addresses because the translated names with brackets aren't valid URLs, e.g. http://[localhost]:8080.
