### PR TITLE
Zero out the lwan_t passed in to lwan_init()

### DIFF
--- a/common/lwan.c
+++ b/common/lwan.c
@@ -452,6 +452,7 @@ void
 lwan_init(lwan_t *l)
 {
     /* Load defaults */
+    memset(l, 0, sizeof(*l));
     memcpy(&l->config, &default_config, sizeof(default_config));
 
     /* Initialize status first, as it is used by other things during


### PR DESCRIPTION
lwan_module_init() checks that the module_registry hash_table hasn't
already been created but the pointer is never actually set to NULL
before that. This was causing the program to segfault due to garbage
data on the stack.

Fixes the valgrind warning:

==5987== Conditional jump or move depends on uninitialised value(s)
==5987==    at 0x405520: lwan_module_init (lwan.c:59)
==5987==    by 0x406E6C: lwan_init (lwan.c:468)
==5987==    by 0x4054D2: main (main.c:132)
==5987==
