### PR TITLE
callback was replaced with handler in url_map

### DIFF
--- a/lwan.ws/index.html
+++ b/lwan.ws/index.html
@@ -309,7 +309,7 @@ int
 main(void)
 {
     const lwan_url_map_t default_map[] = {
-        { .prefix = "/", .callback = hello_world },
+        { .prefix = "/", .handler = hello_world },
         { .prefix = NULL }
     };
     lwan_t l;


### PR DESCRIPTION
This updates the index.html page to fix the reference to `callback` within the example.  `callback` was replaced with `handler` in the `lwan_url_map_t` struct.  
