### PR TITLE
change STATS_DEBUG output color from blue to grey(to fix  unreadable text)

### DIFF
--- a/common/lwan-status.c
+++ b/common/lwan-status.c
@@ -72,7 +72,7 @@ get_color_start_for_type(lwan_status_type_t type, size_t *len_out)
     else if (type & STATUS_CRITICAL)
         retval = "\033[31;1m";
     else if (type & STATUS_DEBUG)
-        retval = "\033[34m";
+        retval = "\033[37m";
     else if (type & STATUS_PERROR)
         retval = "\033[35m";
     else


### PR DESCRIPTION
Dark blue color causes Xfce-terminal to output unreadable text (cant be seen from background).
 change to grey:
-will give the feeling this is debug output on first look
-will fix text problem on xfce-terminal and others
