### PR TITLE
Fixes an errornous call to pthread_rwlock_trywrlock instead of pthread_rwlock_wrlock.

### DIFF
--- a/common/lwan-cache.c
+++ b/common/lwan-cache.c
@@ -337,13 +337,13 @@ static bool cache_pruner_job(void *data)
 
     /* Prepend local, unprocessed queue, to the cache queue. Since the cache
      * item TTL is constant, items created later will be destroyed later. */
-    if (pthread_rwlock_trywrlock(&cache->queue.lock) >= 0) {
+    if (pthread_rwlock_wrlock(&cache->queue.lock) >= 0) {
         list_prepend_list(&cache->queue.list, &queue);
 
         if (pthread_rwlock_unlock(&cache->queue.lock) < 0)
             lwan_status_perror("pthread_rwlock_unlock");
     } else {
-        lwan_status_perror("pthread_rwlock_trywrlock");
+        lwan_status_perror("pthread_rwlock_wrlock");
     }
 
 end:


### PR DESCRIPTION
I'm just walking through lwan sources and I'm asking myself why https://github.com/lpereira/lwan/blob/master/common/lwan-cache.c#L340 is calling `pthread_rwlock_trywrlock` instead of `pthread_rwlock_wrlock`.

As I understand the code, the lock could be acquired at https://github.com/lpereira/lwan/blob/master/common/lwan-cache.c#L229 by a concurrent thread during the execution of `cache_pruner_job`. If this happens, the cache LRU queue will miss some entries and these will never be removed by cache_pruner_job.

I suggest to aquire the lock with a blocking call.