### PR TITLE
Removes a unseless field in a struct of lwan-http-authorize.c

### DIFF
--- a/common/lwan-cache.c
+++ b/common/lwan-cache.c
@@ -337,13 +337,13 @@ static bool cache_pruner_job(void *data)
 
     /* Prepend local, unprocessed queue, to the cache queue. Since the cache
      * item TTL is constant, items created later will be destroyed later. */
-    if (pthread_rwlock_trywrlock(&cache->queue.lock) >= 0) {
+    if (pthread_rwlock_wrlock(&cache->queue.lock) >= 0) {
         list_prepend_list(&cache->queue.list, &queue);
 
         if (pthread_rwlock_unlock(&cache->queue.lock) < 0)
             lwan_status_perror("pthread_rwlock_unlock");
     } else {
-        lwan_status_perror("pthread_rwlock_trywrlock");
+        lwan_status_perror("pthread_rwlock_wrlock");
     }
 
 end:

--- a/common/lwan-http-authorize.c
+++ b/common/lwan-http-authorize.c
@@ -28,7 +28,6 @@
 #include "lwan-http-authorize.h"
 
 struct realm_password_file_t {
-    struct cache_entry_t base;
     struct hash *entries;
 };
 


### PR DESCRIPTION
The struct is not exposed to other compilation units, and the field is not used
in the compilation unit at all. Thus the field seems useless to me.