### PR TITLE
Add 'request_id' to request struct and populate with uuid

### DIFF
--- a/common/hash.c
+++ b/common/hash.c
@@ -84,7 +84,8 @@ void hash_random(void *p, unsigned short size)
             return;
     }
 
-	assert(read(fd, p, size) == size);
+    size -= read(fd, p, size);
+    assert(!size);
     close(fd);
 }
 

--- a/common/hash.h
+++ b/common/hash.h
@@ -15,6 +15,7 @@ struct hash *hash_int_new(void (*free_key)(void *value),
 			void (*free_value)(void *value));
 struct hash *hash_str_new(void (*free_key)(void *value),
 			void (*free_value)(void *value));
+void hash_random(void *p, unsigned short size);
 void hash_free(struct hash *hash);
 int hash_add(struct hash *hash, const void *key, const void *value);
 int hash_add_unique(struct hash *hash, const void *key, const void *value);

--- a/common/lwan.h
+++ b/common/lwan.h
@@ -184,6 +184,7 @@ struct lwan_request_t_ {
     lwan_value_t url;
     lwan_value_t original_url;
     lwan_connection_t *conn;
+    char *id;
 
     struct {
         lwan_key_value_t *base;
@@ -230,10 +231,11 @@ struct lwan_thread_t_ {
     struct {
         char date[30];
         char expires[30];
-        time_t last;
+        struct timespec last;
     } date;
     short id;
-
+    unsigned short clock_seq;
+    unsigned long long node;
     pthread_t self;
     int epoll_fd;
     int pipe_fd[2];

--- a/lwan/main.c
+++ b/lwan/main.c
@@ -85,8 +85,9 @@ hello_world(lwan_request_t *request,
             lwan_response_t *response,
             void *data __attribute__((unused)))
 {
-    static lwan_key_value_t headers[] = {
+    lwan_key_value_t headers[] = {
         { .key = "X-The-Answer-To-The-Universal-Question", .value = "42" },
+        { .key = "X-Request-Id", .value = request->id },
         { NULL, NULL }
     };
     response->headers = headers;

--- a/tools/testsuite.py
+++ b/tools/testsuite.py
@@ -7,7 +7,9 @@ import subprocess
 import time
 import unittest
 import requests
+import datetime
 import socket
+import uuid
 import sys
 import os
 import re
@@ -299,12 +301,24 @@ class TestHelloWorld(LwanTest):
     self.assertEqual(r.text, '')
 
 
+  def test_has_request_id(self):
+    time = datetime.datetime.utcnow()
+    r = requests.get('http://127.0.0.1:8080/hello')
+    self.assertTrue('x-request-id' in r.headers)
+    request_id = uuid.UUID(r.headers['x-request-id'])
+    request_time = datetime.datetime.utcfromtimestamp(
+      (request_id.time - 0x01b21dd213814000L) * 100 / 1e9
+    )
+    self.assertLess(
+      (request_time - time).total_seconds(),
+      0.001
+    )
+
   def test_has_custom_header(self):
     r = requests.get('http://127.0.0.1:8080/hello')
 
     self.assertTrue('x-the-answer-to-the-universal-question' in r.headers)
     self.assertEqual(r.headers['x-the-answer-to-the-universal-question'], '42')
-
 
   def test_no_param(self):
     r = requests.get('http://127.0.0.1:8080/hello')


### PR DESCRIPTION
The request id is a universally unique identifier (specifically, a UUID version 1) that can be attached to logging output as well as added to the response, for instance in the form of a 'X-Request-Id' header.
