### PR TITLE
Remove off by one error in internal_printf

### DIFF
--- a/common/strbuf.c
+++ b/common/strbuf.c
@@ -211,7 +211,7 @@ internal_printf(strbuf_t *s1, bool (*save_str)(strbuf_t *, const char *, size_t)
     if (UNLIKELY((len = vasprintf(&s2, fmt, values)) < 0))
         return false;
 
-    bool success = save_str(s1, s2, (size_t)len);
+    bool success = save_str(s1, s2, (size_t)len + 1);
     free(s2);
 
     return success;


### PR DESCRIPTION
when called here, save_str is expecting a size, but is given a length.