### PR TITLE
Reduce .eh_frame section bloatedness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ else ()
 endif()
 
 set(CMAKE_C_FLAGS "-Wall -Wextra -Wshadow -Wconversion -std=gnu11")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${C_FLAGS_REL}")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${C_FLAGS_REL} -fno-asynchronous-unwind-tables")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${C_FLAGS_REL}")
 set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} ${C_FLAGS_REL}")
 add_definitions("-D_FILE_OFFSET_BITS=64")


### PR DESCRIPTION
Section .eh_frame holds all the "exception handler framework" information from
gcc. It is based on the DWARF format's call frame information (CFI) [1]
and holds information that can be useful for debuggers but also for language
constructs that relies on always having stack unwinding information (i.e. exceptions).
Such constructs, however, are pretty much useless for the C language and are
mainly just used on C++. Furthermore, this section can not be removed by 'strip'
since it is one of the loadable sections of a binary. Its features also take
extra space on .text.

This patch allows gcc to clean-up this section by using -fno-asynchronous-unwind-tables
on release builds.

Before:
> wc -c ./build/lwan/lwan
161448 build/lwan/lwan

After:
> wc -c ./build/lwan/lwan
146408 build/lwan/lwan

This means a reduction of 15040 bytes on binary size, mostly from .text and .eh_frame sections.

[1] http://comments.gmane.org/gmane.comp.standards.dwarf/222