### PR TITLE
Add support for proxy protocol

### DIFF
--- a/common/lwan-coro.c
+++ b/common/lwan-coro.c
@@ -147,7 +147,7 @@ coro_entry_point(coro_t *coro, coro_function_t func)
     coro_yield(coro, return_value);
 }
 
-static void
+void
 coro_run_deferred(coro_t *coro)
 {
     for (coro_defer_t *defer = coro->defer; defer;) {

--- a/common/lwan-coro.h
+++ b/common/lwan-coro.h
@@ -55,6 +55,7 @@ void   *coro_get_data(coro_t *coro);
 void    coro_defer(coro_t *coro, void (*func)(void *data), void *data);
 void    coro_defer2(coro_t *coro, void (*func)(void *data1, void *data2),
             void *data1, void *data2);
+void    coro_run_deferred(coro_t *coro);
 void   *coro_malloc(coro_t *coro, size_t sz);
 void   *coro_malloc_full(coro_t *coro, size_t size, void (*destroy_func)());
 char   *coro_strdup(coro_t *coro, const char *str);

--- a/common/lwan-request.c
+++ b/common/lwan-request.c
@@ -100,6 +100,8 @@ get_http_method(const char *buffer)
 static lwan_request_flags_t
 parse_proxy_protocol(lwan_request_t *request, char **buffer, int version)
 {
+    if (!request->conn->thread->lwan->config.proxy_protocol) return 0;
+
     union header_t_ {
         struct {
             char line[108];

--- a/common/lwan-request.c
+++ b/common/lwan-request.c
@@ -70,9 +70,12 @@ get_http_method(const char *buffer)
 {
     /* Note: keep in sync in identify_http_method() */
     enum {
-        HTTP_STR_GET  = MULTICHAR_CONSTANT('G','E','T',' '),
-        HTTP_STR_HEAD = MULTICHAR_CONSTANT('H','E','A','D'),
-        HTTP_STR_POST = MULTICHAR_CONSTANT('P','O','S','T')
+        HTTP_STR_GET     = MULTICHAR_CONSTANT('G','E','T',' '),
+        HTTP_STR_HEAD    = MULTICHAR_CONSTANT('H','E','A','D'),
+        HTTP_STR_POST    = MULTICHAR_CONSTANT('P','O','S','T'),
+        HTTP_STR_PROXY1  = MULTICHAR_CONSTANT('P','R','O','X'),
+        HTTP_STR_PROXY21 = MULTICHAR_CONSTANT('\x00','\x0D','\x0A','\x51'),
+        HTTP_STR_PROXY22 = MULTICHAR_CONSTANT('\x55','\x49','\x54','\x0A')
     };
 
     STRING_SWITCH(buffer) {
@@ -82,25 +85,256 @@ get_http_method(const char *buffer)
         return REQUEST_METHOD_HEAD;
     case HTTP_STR_POST:
         return REQUEST_METHOD_POST;
+    case HTTP_STR_PROXY1:
+        if (buffer[4] != 'Y') break;
+        return REQUEST_METHOD_PROXY1;
+    case HTTP_STR_PROXY21:
+        if ((string_as_int32(buffer + 4) == HTTP_STR_PROXY22) &&
+            (*(buffer + 8) >> 4 == 2))
+            return REQUEST_METHOD_PROXY2;
     }
 
     return 0;
 }
 
+static lwan_request_flags_t
+parse_proxy_protocol(lwan_request_t *request, char **buffer, int version)
+{
+    union header_t_ {
+        struct {
+            char line[108];
+        } v1;
+        struct {
+            uint8_t sig[8];
+            uint8_t cmd : 4;
+            uint8_t ver : 4;
+            uint8_t fam;
+            uint16_t len;
+            union {
+                struct {
+                        uint32_t src_addr;
+                        uint32_t dst_addr;
+                        uint16_t src_port;
+                        uint16_t dst_port;
+                } ip4;
+                struct {
+                         uint8_t src_addr[16];
+                         uint8_t dst_addr[16];
+                         uint16_t src_port;
+                         uint16_t dst_port;
+                } ip6;
+                struct {
+                         uint8_t src_addr[108];
+                         uint8_t dst_addr[108];
+                } unx;
+            } addr;
+        } v2;
+    };
+
+    unsigned int size;
+    lwan_proxy_t *proxy = &request->conn->thread->lwan->proxies[request->fd];
+    union header_t_ *hdr = (union header_t_ *) *buffer;
+
+    if (version == 1) {
+        char *end, *ptr, *protocol, *src_addr, *dst_addr, *src_port, *dst_port;
+
+        end = memchr(hdr->v1.line, '\r', sizeof(*hdr));
+        if (!end || end[1] != '\n') {
+            return 0;
+        }
+
+        *end = '\0';
+        size = (unsigned int) (end + 2 - hdr->v1.line);
+
+        ptr = hdr->v1.line;
+        strsep(&ptr, " ");
+
+        protocol = strsep(&ptr, " ");
+        src_addr = strsep(&ptr, " ");
+        dst_addr = strsep(&ptr, " ");
+        src_port = strsep(&ptr, " ");
+        dst_port = ptr;
+
+        if (protocol != NULL && dst_port != NULL) {
+            enum {
+                TCP4 = MULTICHAR_CONSTANT('T', 'C', 'P', '4'),
+                TCP6 = MULTICHAR_CONSTANT('T', 'C', 'P', '6')
+            };
+
+            STRING_SWITCH(protocol) {
+            case TCP4:
+                do {
+                    long porttmp;
+
+                    struct sockaddr_in *from = &proxy->from.ipv4;
+                    struct sockaddr_in *to = &proxy->to.ipv4;
+
+                    from->sin_family = to->sin_family = AF_INET;
+
+                    if (inet_pton(AF_INET, src_addr, &from->sin_addr) != 1) {
+                        return 0;
+                    }
+
+                    if (inet_pton(AF_INET, dst_addr, &to->sin_addr) != 1) {
+                        return 0;
+                    }
+
+                    porttmp = strtol(src_port, NULL, 10);
+                    if (!(porttmp > 0 && porttmp < 65536)) {
+                        return 0;
+                    }
+                    from->sin_port = htons((uint16_t) porttmp);
+
+                    porttmp = strtol(dst_port, NULL, 10);
+                    if (!(porttmp > 0 && porttmp < 65536)) {
+                        return 0;
+                    }
+
+                    to->sin_port = htons((uint16_t) porttmp);
+                } while (0);
+                break;
+            case TCP6:
+                do {
+                    long porttmp;
+
+                    struct sockaddr_in6 *from = &proxy->from.ipv6;
+                    struct sockaddr_in6 *to = &proxy->to.ipv6;
+
+                    from->sin6_family = to->sin6_family = AF_INET6;
+
+                    if (inet_pton(AF_INET6, src_addr, &from->sin6_addr) != 1) {
+                        return 0;
+                    }
+
+                    if (inet_pton(AF_INET6, dst_addr, &to->sin6_addr) != 1) {
+                        return 0;
+                    }
+
+                    porttmp = strtol(src_port, NULL, 10);
+                    if (!(porttmp > 0 && porttmp < 65536)) {
+                        return 0;
+                    }
+
+                    from->sin6_port = htons((uint16_t) porttmp);
+
+                    porttmp = strtol(dst_port, NULL, 10);
+                    if (!(porttmp > 0 && porttmp < 65536)) {
+                        return 0;
+                    }
+
+                    to->sin6_port = htons((uint16_t) porttmp);
+                } while (0);
+                break;
+            default:
+                if (memcmp(protocol, "UNKNOWN", 7) != 0) return 0;
+
+                struct sockaddr_in *from = &proxy->from.ipv4;
+                struct sockaddr_in *to = &proxy->to.ipv4;
+
+                from->sin_family = to->sin_family = AF_UNSPEC;
+            }
+        }
+
+        goto done;
+    }
+
+    if (version == 2) {
+        size = 12 + (unsigned int) ntohs(hdr->v2.len);
+        if (size > sizeof(union header_t_)) return 0;
+
+        enum {
+            LOCAL = 0,
+            PROXY = 1
+        };
+
+        switch (hdr->v2.cmd) {
+        case LOCAL:
+            do {
+                struct sockaddr_in *from = &proxy->from.ipv4;
+                struct sockaddr_in *to = &proxy->to.ipv4;
+
+                from->sin_family = to->sin_family = AF_UNSPEC;
+            } while (0);
+            break;
+        case PROXY:
+            do {
+                enum {
+                    TCP4 = 0x11,
+                    TCP6 = 0x21
+                };
+
+                switch (hdr->v2.fam) {
+                case TCP4:
+                    do {
+                        struct sockaddr_in *from = &proxy->from.ipv4;
+                        struct sockaddr_in *to = &proxy->to.ipv4;
+
+                        to->sin_family = from->sin_family = AF_INET;
+
+                        from->sin_addr.s_addr = hdr->v2.addr.ip4.src_addr;
+                        from->sin_port = hdr->v2.addr.ip4.src_port;
+
+                        to->sin_addr.s_addr = hdr->v2.addr.ip4.dst_addr;
+                        to->sin_port = hdr->v2.addr.ip4.dst_port;
+                    } while (0);
+                    break;
+                case TCP6:
+                    do {
+                        struct sockaddr_in6 *from = &proxy->from.ipv6;
+                        struct sockaddr_in6 *to = &proxy->to.ipv6;
+
+                        from->sin6_family = to->sin6_family = AF_INET6;
+
+                        memcpy(&from->sin6_addr, hdr->v2.addr.ip6.src_addr, 16);
+                        from->sin6_port = hdr->v2.addr.ip6.src_port;
+
+                        memcpy(&to->sin6_addr, hdr->v2.addr.ip6.dst_addr, 16);
+                        to->sin6_port = hdr->v2.addr.ip6.dst_port;
+                    } while (0);
+                    break;
+                default:
+                    return 0;
+                }
+            } while (0);
+            break;
+        default:
+            return 0;
+        }
+
+        goto done;
+    }
+
+    return 0;
+
+ done:
+    request->conn->flags |= CONN_PROXIED;
+    *buffer += size;
+    return get_http_method(*buffer);
+}
+
 static ALWAYS_INLINE char *
 identify_http_method(lwan_request_t *request, char *buffer)
 {
+    char *path;
     lwan_request_flags_t flags = get_http_method(buffer);
+
+    if (flags == REQUEST_METHOD_PROXY1)
+        flags = parse_proxy_protocol(request, &buffer, 1);
+
+    if (flags == REQUEST_METHOD_PROXY2)
+        flags = parse_proxy_protocol(request, &buffer, 2);
+
     static const char sizes[] = {
-        [REQUEST_METHOD_GET] = sizeof("GET ") - 1,
-        [REQUEST_METHOD_HEAD] = sizeof("HEAD ") - 1,
-        [REQUEST_METHOD_POST] = sizeof("POST ") - 1,
+        [REQUEST_METHOD_GET] = sizeof("GET") - 1,
+        [REQUEST_METHOD_HEAD] = sizeof("HEAD") - 1,
+        [REQUEST_METHOD_POST] = sizeof("POST") - 1,
     };
 
     if (flags) {
-        buffer += sizes[flags];
-        if (*buffer == ' ') {
+        path = buffer + sizes[flags] + 1;
+        if (*(path - 1) == ' ') {
             request->flags |= flags;
+            buffer = path;
         }
     }
 
@@ -672,15 +906,15 @@ read_post_data(lwan_request_t *request __attribute__((unused)),
 static lwan_http_status_t
 parse_http_request(lwan_request_t *request, struct request_parser_helper *helper)
 {
-    char *buffer;
-
-    buffer = ignore_leading_whitespace(helper->buffer->value);
-    if (UNLIKELY(!*buffer))
-        return HTTP_BAD_REQUEST;
+    char *buffer = ignore_leading_whitespace(helper->buffer->value);
 
     char *path = identify_http_method(request, buffer);
-    if (UNLIKELY(buffer == path))
+    if (UNLIKELY(buffer == path)) {
+        if (UNLIKELY(!*buffer))
+            return HTTP_BAD_REQUEST;
+
         return HTTP_NOT_ALLOWED;
+    }
 
     buffer = identify_http_path(request, path, helper);
     if (UNLIKELY(!buffer))
@@ -888,14 +1122,26 @@ const char *
 lwan_request_get_remote_address(lwan_request_t *request,
             char buffer[static INET6_ADDRSTRLEN])
 {
-    struct sockaddr_storage sock_addr = { 0 };
-    socklen_t sock_len = sizeof(struct sockaddr_storage);
-    if (UNLIKELY(getpeername(request->fd, (struct sockaddr *)&sock_addr, &sock_len) < 0))
-        return NULL;
+    struct sockaddr_storage __sock_addr;
+    struct sockaddr_storage *sock_addr = &__sock_addr;
 
-    if (sock_addr.ss_family == AF_INET)
-        return inet_ntop(AF_INET, &((struct sockaddr_in *)&sock_addr)->sin_addr,
+    if (request->conn->flags & CONN_PROXIED) {
+        sock_addr = (struct sockaddr_storage *)
+            &request->conn->thread->lwan->proxies[request->fd].from;
+    } else {
+        socklen_t sock_len = sizeof(__sock_addr);
+        if (UNLIKELY(getpeername(request->fd,
+                                 (struct sockaddr *) sock_addr,
+                                 &sock_len) < 0))
+            return NULL;
+    }
+
+    if (sock_addr->ss_family == AF_INET)
+        return inet_ntop(AF_INET,
+                         &((struct sockaddr_in *) sock_addr)->sin_addr,
                          buffer, INET6_ADDRSTRLEN);
-    return inet_ntop(AF_INET6, &((struct sockaddr_in6 *)&sock_addr)->sin6_addr,
+
+    return inet_ntop(AF_INET6,
+                     &((struct sockaddr_in6 *) sock_addr)->sin6_addr,
                      buffer, INET6_ADDRSTRLEN);
 }

--- a/common/lwan-request.c
+++ b/common/lwan-request.c
@@ -92,13 +92,19 @@ identify_http_method(lwan_request_t *request, char *buffer)
 {
     lwan_request_flags_t flags = get_http_method(buffer);
     static const char sizes[] = {
-        [0] = 0,
         [REQUEST_METHOD_GET] = sizeof("GET ") - 1,
         [REQUEST_METHOD_HEAD] = sizeof("HEAD ") - 1,
         [REQUEST_METHOD_POST] = sizeof("POST ") - 1,
     };
-    request->flags |= flags;
-    return buffer + sizes[flags];
+
+    if (flags) {
+        buffer += sizes[flags];
+        if (*buffer == ' ') {
+            request->flags |= flags;
+        }
+    }
+
+    return buffer;
 }
 
 static ALWAYS_INLINE char

--- a/common/lwan-thread.c
+++ b/common/lwan-thread.c
@@ -164,7 +164,7 @@ process_request_coro(coro_t *coro)
 
         next_request = lwan_process_request(lwan, &request, &buffer, next_request);
         if (!next_request)
-            break;
+            coro_run_deferred(coro);
 
         coro_yield(coro, CONN_CORO_MAY_RESUME);
 
@@ -362,7 +362,6 @@ thread_io_loop(void *data)
                         continue;
                     }
 
-                    spawn_or_reset_coro_if_needed(conn, &switcher, &dq);
                     resume_coro_if_needed(&dq, conn, epoll_fd);
                 }
 

--- a/common/lwan.c
+++ b/common/lwan.c
@@ -466,8 +466,14 @@ static void
 allocate_connections(lwan_t *l, size_t max_open_files)
 {
     l->conns = calloc(max_open_files, sizeof(lwan_connection_t));
-    if (!l->conns)
-        lwan_status_critical_perror("calloc");
+    if (!l->conns) goto err;
+
+    l->proxies = calloc(max_open_files, sizeof(lwan_proxy_t));
+    if (!l->proxies) goto err;
+
+    return;
+ err:
+    lwan_status_critical_perror("calloc");
 }
 
 static unsigned short int

--- a/common/lwan.c
+++ b/common/lwan.c
@@ -48,6 +48,7 @@ static const lwan_config_t default_config = {
     .keep_alive_timeout = 15,
     .quiet = false,
     .reuse_port = false,
+    .proxy_protocol = false,
     .expires = 1 * ONE_WEEK,
     .n_threads = 0
 };
@@ -399,6 +400,9 @@ static bool setup_from_config(lwan_t *lwan)
             else if (!strcmp(line.line.key, "reuse_port"))
                 lwan->config.reuse_port = parse_bool(line.line.value,
                             default_config.reuse_port);
+            else if (!strcmp(line.line.key, "proxy_protocol"))
+                lwan->config.proxy_protocol = parse_bool(line.line.value,
+                            default_config.proxy_protocol);
             else if (!strcmp(line.line.key, "expires"))
                 lwan->config.expires = parse_time_period(line.line.value,
                             default_config.expires);

--- a/common/lwan.h
+++ b/common/lwan.h
@@ -110,6 +110,7 @@ typedef struct lwan_thread_t_		lwan_thread_t;
 typedef struct lwan_url_map_t_		lwan_url_map_t;
 typedef struct lwan_value_t_		lwan_value_t;
 typedef struct lwan_config_t_		lwan_config_t;
+typedef struct lwan_proxy_t_		lwan_proxy_t;
 typedef struct lwan_connection_t_	lwan_connection_t;
 
 typedef enum {
@@ -150,13 +151,15 @@ typedef enum {
     REQUEST_METHOD_GET         = 1<<0,
     REQUEST_METHOD_HEAD        = 1<<1,
     REQUEST_METHOD_POST        = 1<<2,
-    REQUEST_ACCEPT_DEFLATE     = 1<<3,
-    REQUEST_ACCEPT_GZIP        = 1<<4,
-    REQUEST_IS_HTTP_1_0        = 1<<5,
-    RESPONSE_SENT_HEADERS      = 1<<6,
-    RESPONSE_CHUNKED_ENCODING  = 1<<7,
-    RESPONSE_NO_CONTENT_LENGTH = 1<<8,
-    RESPONSE_URL_REWRITTEN     = 1<<9
+    REQUEST_METHOD_PROXY1      = 1<<3,
+    REQUEST_METHOD_PROXY2      = 1<<4,
+    REQUEST_ACCEPT_DEFLATE     = 1<<5,
+    REQUEST_ACCEPT_GZIP        = 1<<6,
+    REQUEST_IS_HTTP_1_0        = 1<<7,
+    RESPONSE_SENT_HEADERS      = 1<<8,
+    RESPONSE_CHUNKED_ENCODING  = 1<<9,
+    RESPONSE_NO_CONTENT_LENGTH = 1<<10,
+    RESPONSE_URL_REWRITTEN     = 1<<11
 } lwan_request_flags_t;
 
 typedef enum {
@@ -165,7 +168,8 @@ typedef enum {
     CONN_IS_ALIVE           = 1<<1,
     CONN_SHOULD_RESUME_CORO = 1<<2,
     CONN_WRITE_EVENTS       = 1<<3,
-    CONN_MUST_READ          = 1<<4
+    CONN_MUST_READ          = 1<<4,
+    CONN_PROXIED            = 1<<5
 } lwan_connection_flags_t;
 
 typedef enum {
@@ -277,9 +281,18 @@ struct lwan_config_t_ {
     short unsigned int n_threads;
 };
 
+struct lwan_proxy_t_ {
+    union {
+        int64_t __ss_align;
+        struct sockaddr_in ipv4;
+        struct sockaddr_in6 ipv6;
+    } to, from;
+};
+
 struct lwan_t_ {
     lwan_trie_t url_map_trie;
     lwan_connection_t *conns;
+    lwan_proxy_t *proxies;
 
     struct {
         lwan_thread_t *threads;

--- a/common/lwan.h
+++ b/common/lwan.h
@@ -277,6 +277,7 @@ struct lwan_config_t_ {
     unsigned short keep_alive_timeout;
     bool quiet;
     bool reuse_port;
+    bool proxy_protocol;
     unsigned int expires;
     short unsigned int n_threads;
 };

--- a/lwan.conf
+++ b/lwan.conf
@@ -1,6 +1,7 @@
 keep_alive_timeout = 15
 quiet = false
 reuse_port = false
+proxy_protocol = true
 expires = 1M 1w
 threads = 0
 

--- a/tools/testsuite.py
+++ b/tools/testsuite.py
@@ -27,12 +27,15 @@ class LwanTest(unittest.TestCase):
         [LWAN_PATH],
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT
       )
+      s = socket.socket()
       for request_try in range(20):
         try:
-          requests.get('http://127.0.0.1:8080/hello')
-          return
-        except requests.ConnectionError:
+          s.connect(('127.0.0.1', 8080))
+        except:
           time.sleep(0.1)
+        else:
+          s.close()
+          return
 
       time.sleep(0.1)
 

--- a/tools/testsuite.py
+++ b/tools/testsuite.py
@@ -479,6 +479,31 @@ class TestCache(LwanTest):
     requests.get('http://127.0.0.1:8080/100.html')
     self.assertEqual(self.count_mmaps('/100.html'), 1)
 
+class TestProxyProtocolRequests(SocketTest):
+  def test_proxy_version1(self):
+    req = '''PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r
+GET / HTTP/1.1\r
+Host: 192.168.0.11\r\n\r\n'''
+
+    sock = self.connect()
+    sock.send(req)
+    response = sock.recv(1024)
+    self.assertTrue(response.startswith('HTTP/1.1 200 OK'), response)
+
+  def test_proxy_version2(self):
+    req = (
+      "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A"
+      "\x21\x11\x00\x0B"
+      "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B"
+      "GET / HTTP/1.1\r\n"
+      "Host: 192.168.0.11\r\n\r\n"
+    )
+
+    sock = self.connect()
+    sock.send(req)
+    response = sock.recv(1024)
+    self.assertTrue(response.startswith('HTTP/1.1 200 OK'), response)
+
 class TestPipelinedRequests(SocketTest):
   def test_pipelined_requests(self):
     response_separator = re.compile('\r\n\r\n')

--- a/tools/testsuite.py
+++ b/tools/testsuite.py
@@ -23,9 +23,10 @@ print 'Using', LWAN_PATH, 'for lwan'
 class LwanTest(unittest.TestCase):
   def setUp(self):
     for spawn_try in range(20):
-      self.lwan=subprocess.Popen([LWAN_PATH],
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-
+      self.lwan=subprocess.Popen(
+        [LWAN_PATH],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+      )
       for request_try in range(20):
         try:
           requests.get('http://127.0.0.1:8080/hello')


### PR DESCRIPTION
Note that this adds a ``struct lwan_proxy_t``:
```c
l->proxies = calloc(max_open_files, sizeof(lwan_proxy_t));
``` 
This is a waste of memory when PROXY protocol isn't used. It might be an idea to have a flag that controls whether this is always allocated, lazily allocated or never allocated.

It might be better to add this to the coro's stack?

Fixes https://github.com/lpereira/lwan/issues/117.