### PR TITLE
We don't need to break out of coro

### DIFF
--- a/common/lwan-coro.c
+++ b/common/lwan-coro.c
@@ -147,7 +147,7 @@ coro_entry_point(coro_t *coro, coro_function_t func)
     coro_yield(coro, return_value);
 }
 
-static void
+void
 coro_run_deferred(coro_t *coro)
 {
     for (coro_defer_t *defer = coro->defer; defer;) {

--- a/common/lwan-coro.c
+++ b/common/lwan-coro.c
@@ -32,8 +32,6 @@
 #include <valgrind/valgrind.h>
 #endif
 
-#define CORO_RESET_THRESHOLD	16
-
 #define CORO_STACK_MIN		((3 * (PTHREAD_STACK_MIN)) / 2)
 
 static_assert(DEFAULT_BUFFER_SIZE < (CORO_STACK_MIN + PTHREAD_STACK_MIN),
@@ -44,6 +42,7 @@ typedef struct coro_defer_t_	coro_defer_t;
 struct coro_defer_t_ {
     coro_defer_t *next;
     void (*func)();
+    bool sticky;
     void *data1;
     void *data2;
 };
@@ -60,7 +59,6 @@ struct coro_t_ {
     coro_defer_t *defer;
     void *data;
 
-    unsigned char reset_count;
     bool ended;
 };
 
@@ -148,16 +146,24 @@ coro_entry_point(coro_t *coro, coro_function_t func)
 }
 
 void
-coro_run_deferred(coro_t *coro)
+coro_run_deferred(coro_t *coro, bool sticky)
 {
+    coro_defer_t *first = NULL;
+
     for (coro_defer_t *defer = coro->defer; defer;) {
         coro_defer_t *tmp = defer;
-        defer->func(defer->data1, defer->data2);
         defer = tmp->next;
-        free(tmp);
+        if (!sticky && tmp->sticky) {
+            first = tmp;
+        } else {
+            tmp->func(tmp->data1, tmp->data2);
+            free(tmp);
+        }
     }
-    coro->defer = NULL;
-    coro->reset_count = CORO_RESET_THRESHOLD;
+    coro->defer = first;
+    if (first) {
+        first->next = NULL;
+    }
 }
 
 void
@@ -168,8 +174,8 @@ coro_reset(coro_t *coro, coro_function_t func, void *data)
     coro->ended = false;
     coro->data = data;
 
-    if (!coro->reset_count--)
-        coro_run_deferred(coro);
+    if (coro->defer)
+        coro_run_deferred(coro, true);
 
 #if defined(__x86_64__)
     coro->context[6 /* RDI */] = (uintptr_t) coro;
@@ -209,7 +215,6 @@ coro_new(coro_switcher_t *switcher, coro_function_t function, void *data)
 
     coro->switcher = switcher;
     coro->defer = NULL;
-    coro->reset_count = CORO_RESET_THRESHOLD;
     coro_reset(coro, function, data);
 
 #if !defined(NDEBUG) && defined(USE_VALGRIND)
@@ -279,7 +284,7 @@ coro_free(coro_t *coro)
 #if !defined(NDEBUG) && defined(USE_VALGRIND)
     VALGRIND_STACK_DEREGISTER(coro->vg_stack_id);
 #endif
-    coro_run_deferred(coro);
+    coro_run_deferred(coro, true);
     free(coro);
 }
 
@@ -314,7 +319,7 @@ coro_defer2(coro_t *coro, void (*func)(void *data1, void *data2),
 }
 
 void *
-coro_malloc_full(coro_t *coro, size_t size, void (*destroy_func)())
+coro_malloc_full(coro_t *coro, size_t size, bool sticky, void (*destroy_func)())
 {
     coro_defer_t *defer = malloc(sizeof(*defer) + size);
 
@@ -322,6 +327,7 @@ coro_malloc_full(coro_t *coro, size_t size, void (*destroy_func)())
         return NULL;
 
     defer->next = coro->defer;
+    defer->sticky = sticky;
     defer->func = destroy_func;
     defer->data1 = defer + 1;
     defer->data2 = NULL;
@@ -338,7 +344,7 @@ static void nothing()
 inline void *
 coro_malloc(coro_t *coro, size_t size)
 {
-    return coro_malloc_full(coro, size, nothing);
+    return coro_malloc_full(coro, size, false, nothing);
 }
 
 char *

--- a/common/lwan-coro.h
+++ b/common/lwan-coro.h
@@ -55,9 +55,9 @@ void   *coro_get_data(coro_t *coro);
 void    coro_defer(coro_t *coro, void (*func)(void *data), void *data);
 void    coro_defer2(coro_t *coro, void (*func)(void *data1, void *data2),
             void *data1, void *data2);
-void    coro_run_deferred(coro_t *coro);
+void    coro_run_deferred(coro_t *coro, bool sticky);
 void   *coro_malloc(coro_t *coro, size_t sz);
-void   *coro_malloc_full(coro_t *coro, size_t size, void (*destroy_func)());
+void   *coro_malloc_full(coro_t *coro, size_t size, bool sticky, void (*destroy_func)());
 char   *coro_strdup(coro_t *coro, const char *str);
 char   *coro_printf(coro_t *coro, const char *fmt, ...);
 

--- a/common/lwan-coro.h
+++ b/common/lwan-coro.h
@@ -55,6 +55,7 @@ void   *coro_get_data(coro_t *coro);
 void    coro_defer(coro_t *coro, void (*func)(void *data), void *data);
 void    coro_defer2(coro_t *coro, void (*func)(void *data1, void *data2),
             void *data1, void *data2);
+void    coro_run_deferred(coro_t *coro);
 void   *coro_malloc(coro_t *coro, size_t sz);
 void   *coro_malloc_full(coro_t *coro, size_t size, void (*destroy_func)());
 char   *coro_strdup(coro_t *coro, const char *str);

--- a/common/lwan-thread.c
+++ b/common/lwan-thread.c
@@ -163,9 +163,6 @@ process_request_coro(coro_t *coro)
         assert(conn->flags & CONN_IS_ALIVE);
 
         next_request = lwan_process_request(lwan, &request, &buffer, next_request);
-        if (!next_request)
-            break;
-
         coro_yield(coro, CONN_CORO_MAY_RESUME);
 
         if (UNLIKELY(!strbuf_reset_length(strbuf)))
@@ -362,7 +359,6 @@ thread_io_loop(void *data)
                         continue;
                     }
 
-                    spawn_or_reset_coro_if_needed(conn, &switcher, &dq);
                     resume_coro_if_needed(&dq, conn, epoll_fd);
                 }
 

--- a/common/lwan-thread.c
+++ b/common/lwan-thread.c
@@ -29,6 +29,8 @@
 
 #include "lwan-private.h"
 
+#define CORO_DEFER_THRESHOLD   16
+
 struct death_queue_t {
     const lwan_t *lwan;
     lwan_connection_t *conns;
@@ -138,11 +140,12 @@ min(const int a, const int b)
 static int
 process_request_coro(coro_t *coro)
 {
-    strbuf_t *strbuf = coro_malloc_full(coro, sizeof(*strbuf), strbuf_free);
+    strbuf_t *strbuf = coro_malloc_full(coro, sizeof(*strbuf), true, strbuf_free);
     lwan_connection_t *conn = coro_get_data(coro);
     lwan_t *lwan = conn->thread->lwan;
     int fd = lwan_connection_get_fd(lwan, conn);
     char request_buffer[DEFAULT_BUFFER_SIZE];
+    unsigned char i = 0;
     lwan_value_t buffer = {
         .value = request_buffer,
         .len = 0
@@ -163,8 +166,10 @@ process_request_coro(coro_t *coro)
         assert(conn->flags & CONN_IS_ALIVE);
 
         next_request = lwan_process_request(lwan, &request, &buffer, next_request);
-        if (!next_request)
-            coro_run_deferred(coro);
+        if (++i == CORO_DEFER_THRESHOLD) {
+            coro_run_deferred(coro, false);
+            i = 0;
+        }
 
         coro_yield(coro, CONN_CORO_MAY_RESUME);
 

--- a/common/lwan-thread.c
+++ b/common/lwan-thread.c
@@ -163,6 +163,9 @@ process_request_coro(coro_t *coro)
         assert(conn->flags & CONN_IS_ALIVE);
 
         next_request = lwan_process_request(lwan, &request, &buffer, next_request);
+        if (!next_request)
+            coro_run_deferred(coro);
+
         coro_yield(coro, CONN_CORO_MAY_RESUME);
 
         if (UNLIKELY(!strbuf_reset_length(strbuf)))


### PR DESCRIPTION
Also, this means the coro is always running when keeping the connection alive.