### PR TITLE
Move switcher to thread struct to allow coro injection from outside

### DIFF
--- a/common/lwan-thread.c
+++ b/common/lwan-thread.c
@@ -327,7 +327,7 @@ thread_io_loop(void *data)
     const lwan_t *lwan = t->lwan;
     lwan_connection_t *conns = lwan->conns;
     struct epoll_event *events;
-    coro_switcher_t switcher;
+    coro_switcher_t *switcher = &t->switcher;
     struct death_queue_t dq;
     int n_fds;
 
@@ -364,7 +364,7 @@ thread_io_loop(void *data)
                     if (UNLIKELY(!conn))
                         continue;
 
-                    spawn_coro(conn, &switcher, &dq);
+                    spawn_coro(conn, switcher, &dq);
                 } else {
                     conn = ep_event->data.ptr;
                     if (UNLIKELY(ep_event->events & (EPOLLRDHUP | EPOLLHUP))) {

--- a/common/lwan.h
+++ b/common/lwan.h
@@ -277,6 +277,7 @@ struct lwan_thread_t_ {
     int epoll_fd;
     int pipe_fd[2];
     pthread_t self;
+    coro_switcher_t switcher;
 };
 
 struct lwan_config_t_ {


### PR DESCRIPTION
I use this to co-opt the event loop with a redis connection per thread.

In my setup I connect to redis, clone the file descriptor and set up a reader and writer `coro_t` that both run as `lwan_connection_t` connections.

To inject the coros into the connection pool I use the same shared `switcher` (per thread).
