### PR TITLE
Remove warning on 32 bit ARM build

### DIFF
--- a/common/strbuf.c
+++ b/common/strbuf.c
@@ -37,11 +37,11 @@ find_next_power_of_two(size_t number)
     static const int size_bits = (int)sizeof(number) * CHAR_BIT;
 
     if (sizeof(size_t) == sizeof(unsigned int)) {
-        return 1U << (size_bits - __builtin_clz((unsigned int)number));
+        return (size_t)1 << (size_bits - __builtin_clz((unsigned int)number));
     } else if (sizeof(size_t) == sizeof(unsigned long)) {
-        return 1UL << (size_bits - __builtin_clzl((unsigned long)number));
+        return (size_t)1 << (size_bits - __builtin_clzl((unsigned long)number));
     } else if (sizeof(size_t) == sizeof(unsigned long long)) {
-        return 1ULL << (size_bits - __builtin_clzll((unsigned long long)number));
+        return (size_t)1 << (size_bits - __builtin_clzll((unsigned long long)number));
     } else {
         (void)size_bits;
     }


### PR DESCRIPTION
This patch works around a gcc deficiency that evaluates all possible
architecture specific code paths, instead of only evaluating the correct
one, resulting in warnings on the incorrect code paths.

Results in identical code, confirmed with sha512sum, in the following build environments:

- gcc + arm
- clang + arm
- gcc + amd64
- clang + amd64
