### PR TITLE
Support for cross-domain requests

### DIFF
--- a/common/lwan-request.c
+++ b/common/lwan-request.c
@@ -268,6 +268,7 @@ identify_http_method(lwan_request_t *request, char *buffer)
         HTTP_STR_GET     = MULTICHAR_CONSTANT('G','E','T',' '),
         HTTP_STR_HEAD    = MULTICHAR_CONSTANT('H','E','A','D'),
         HTTP_STR_POST    = MULTICHAR_CONSTANT('P','O','S','T'),
+        HTTP_STR_OPTIONS = MULTICHAR_CONSTANT('O','P','T','I'),
     };
 
     STRING_SWITCH(buffer) {
@@ -280,6 +281,9 @@ identify_http_method(lwan_request_t *request, char *buffer)
     case HTTP_STR_POST:
         request->flags |= REQUEST_METHOD_POST;
         return buffer + sizeof("POST ") - 1;
+    case HTTP_STR_OPTIONS:
+        request->flags |= REQUEST_METHOD_OPTIONS;
+        return buffer + sizeof("OPTIONS ") - 1;
     }
 
     return NULL;

--- a/common/lwan-response.c
+++ b/common/lwan-response.c
@@ -105,6 +105,8 @@ get_request_method(lwan_request_t *request)
         return "HEAD";
     if (request->flags & REQUEST_METHOD_POST)
         return "POST";
+    if (request->flags & REQUEST_METHOD_OPTIONS)
+        return "OPTIONS";
     return "UNKNOWN";
 }
 
@@ -173,7 +175,7 @@ lwan_response(lwan_request_t *request, lwan_http_status_t status)
         return;
     }
 
-    if (request->flags & REQUEST_METHOD_HEAD) {
+    if (request->flags & (REQUEST_METHOD_HEAD | REQUEST_METHOD_OPTIONS)) {
         lwan_write(request, headers, header_len);
         return;
     }
@@ -260,6 +262,8 @@ lwan_prepare_response_header(lwan_request_t *request, lwan_http_status_t status,
         APPEND_CONSTANT("\r\nContent-Length: ");
         if (request->response.stream.callback)
             APPEND_UINT(request->response.content_length);
+        else if (request->flags & REQUEST_METHOD_OPTIONS)
+            APPEND_UINT(0);
         else
             APPEND_UINT(strbuf_get_length(request->response.buffer));
     }

--- a/common/lwan-response.c
+++ b/common/lwan-response.c
@@ -317,6 +317,13 @@ lwan_prepare_response_header(lwan_request_t *request, lwan_http_status_t status,
         APPEND_STRING_LEN(request->conn->thread->date.expires, 29);
     }
 
+    if (request->conn->thread->lwan->config.allow_cors) {
+        APPEND_CONSTANT("\r\nAccess-Control-Allow-Origin: *");
+        APPEND_CONSTANT("\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS");
+        APPEND_CONSTANT("\r\nAccess-Control-Allow-Credentials: true");
+        APPEND_CONSTANT("\r\nAccess-Control-Allow-Headers: Origin, Accept, Content-Type");
+    }
+
     APPEND_CONSTANT("\r\nServer: lwan\r\n\r\n\0");
 
     return (size_t)(p_headers - headers - 1);

--- a/common/lwan.c
+++ b/common/lwan.c
@@ -50,6 +50,7 @@ static const lwan_config_t default_config = {
     .quiet = false,
     .reuse_port = false,
     .proxy_protocol = false,
+    .allow_cors = false,
     .expires = 1 * ONE_WEEK,
     .n_threads = 0,
     .max_post_data_size = 10 * DEFAULT_BUFFER_SIZE
@@ -401,6 +402,9 @@ static bool setup_from_config(lwan_t *lwan, const char *path)
             } else if (streq(line.line.key, "proxy_protocol")) {
                 lwan->config.proxy_protocol = parse_bool(line.line.value,
                             default_config.proxy_protocol);
+            } else if (!strcmp(line.line.key, "allow_cors")) {
+				lwan->config.allow_cors = parse_bool(line.line.value,
+				            default_config.allow_cors);
             } else if (streq(line.line.key, "expires")) {
                 lwan->config.expires = parse_time_period(line.line.value,
                             default_config.expires);

--- a/common/lwan.h
+++ b/common/lwan.h
@@ -152,15 +152,16 @@ typedef enum {
     REQUEST_METHOD_GET         = 1<<0,
     REQUEST_METHOD_HEAD        = 1<<1,
     REQUEST_METHOD_POST        = 1<<2,
-    REQUEST_ACCEPT_DEFLATE     = 1<<3,
-    REQUEST_ACCEPT_GZIP        = 1<<4,
-    REQUEST_IS_HTTP_1_0        = 1<<5,
-    RESPONSE_SENT_HEADERS      = 1<<6,
-    RESPONSE_CHUNKED_ENCODING  = 1<<7,
-    RESPONSE_NO_CONTENT_LENGTH = 1<<8,
-    RESPONSE_URL_REWRITTEN     = 1<<9,
-    REQUEST_ALLOW_PROXY_REQS   = 1<<10,
-    REQUEST_PROXIED            = 1<<11
+    REQUEST_METHOD_OPTIONS     = 1<<3,
+    REQUEST_ACCEPT_DEFLATE     = 1<<4,
+    REQUEST_ACCEPT_GZIP        = 1<<5,
+    REQUEST_IS_HTTP_1_0        = 1<<6,
+    RESPONSE_SENT_HEADERS      = 1<<7,
+    RESPONSE_CHUNKED_ENCODING  = 1<<8,
+    RESPONSE_NO_CONTENT_LENGTH = 1<<9,
+    RESPONSE_URL_REWRITTEN     = 1<<10,
+    REQUEST_ALLOW_PROXY_REQS   = 1<<11,
+    REQUEST_PROXIED            = 1<<12
 } lwan_request_flags_t;
 
 typedef enum {

--- a/common/lwan.h
+++ b/common/lwan.h
@@ -294,6 +294,7 @@ struct lwan_config_t_ {
     bool quiet;
     bool reuse_port;
     bool proxy_protocol;
+    bool allow_cors;
 };
 
 struct lwan_t_ {


### PR DESCRIPTION
A word of caution: this is officially my first® pull request on GitHub. If I did something wrong or if I messed this up completely, please stay nice ;)

What is this? Sometimes there is the need to request data from a server on a different domain or a different machine on a local network. This may be done by using Javascript (e.g. jQuery) and is considered a 'cross-domain request', which is usually not allowed. To allow such kind of requests the webserver has to explicitly do it by sending additional information inside the response header. What makes things worse is the browser doing a 'preflight request' by performing an additional request using the request method 'OPTIONS' before issuing the actual request to the desired resource.

As this is a very convoluted topic, I did some research about CORS (Cross-Origin Resource Sharing). There is good documentation [here](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html) (sec. 9.2) and [here](http://enable-cors.org/server.html).

The two patches do not implement the full specification. They are merely a starting point. Just put "allow_cors = yes" in the top level of the configuration file (outside the listener section) to enable CORS support. That is enough to make things work on my end.

Of course there could be many more options and additional logic, but remember that this is a rather special use case and I would like some feedback on the topic first.