### PR TITLE
Fix memory leak when reassigning trie's leaf

### DIFF
--- a/common/lwan-trie.c
+++ b/common/lwan-trie.c
@@ -84,6 +84,11 @@ lwan_trie_add(lwan_trie_t *trie, const char *key, void *data)
         if (!leaf)
             lwan_status_critical_perror("malloc");
     }
+    else
+    {
+        if (trie->free_node)
+            trie->free_node(leaf->data);
+    }
 
     leaf->data = data;
     if (!had_key) {


### PR DESCRIPTION
In function `lwan_trie_add` (https://github.com/lpereira/lwan/blob/master/common/lwan-trie.c#L88) there's a memory leak that reveals itself whenever we try to add the node with the same key. Leaf's data is simply reassigned to the new value, forgetting the previous one.

```c
void free_int(void* data)
{
    free(data);
}

int main()
{
    lwan_trie_t url_map_trie;
    lwan_trie_init(&url_map_trie, free_int);

    lwan_trie_add(&url_map_trie, "/info", calloc(1, sizeof(int)));
    lwan_trie_add(&url_map_trie, "/info", calloc(1, sizeof(int)));

    lwan_trie_destroy(&url_map_trie);
}
```