### PR TITLE
Do not print colors on dumb terminals

### DIFF
--- a/src/lib/lwan-status.c
+++ b/src/lib/lwan-status.c
@@ -43,6 +43,8 @@ static volatile bool quiet = false;
 static bool use_colors;
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
+static bool can_use_colors(void);
+
 void
 lwan_status_init(struct lwan *l)
 {
@@ -52,12 +54,27 @@ lwan_status_init(struct lwan *l)
     quiet = false;
     (void) l;
 #endif
-    use_colors = isatty(fileno(stdout));
+    use_colors = can_use_colors();
 }
 
 void
 lwan_status_shutdown(struct lwan *l __attribute__((unused)))
 {
+}
+
+static bool
+can_use_colors(void)
+{
+    const char *term;
+
+    if (!isatty(fileno(stdout)))
+          return false;
+
+    term = secure_getenv("TERM");
+    if (term && streq(term, "dumb"))
+            return false;
+
+    return true;
 }
 
 static const char *


### PR DESCRIPTION
Trivial patch: test for the catch-all "dumb" terminal before printing colors. It's conventional for oddball terminals that don't do ANSI colors to set TERM to "dumb".