### PR TITLE
Fixes a small memory leak in lwan->config.listener

### DIFF
--- a/src/lib/lwan.c
+++ b/src/lib/lwan.c
@@ -323,6 +323,9 @@ void lwan_set_url_map(struct lwan *l, const struct lwan_url_map *map)
 
 static void parse_listener(struct config *c, struct config_line *l, struct lwan *lwan)
 {
+    if (lwan->config.listener != NULL){
+        free(lwan->config.listener);
+    }
     lwan->config.listener = strdup(l->value);
 
     while (config_read_line(c, l)) {


### PR DESCRIPTION
The program almost cleans up all of its resources, but in the parse_listener function strdup() is used to overwrite a pointer to an existing piece of malloc'ed memory without freeing it first.