### PR TITLE
Cross Compilation Fixes

### DIFF
--- a/src/bin/tools/CMakeLists.txt
+++ b/src/bin/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (CMAKE_CROSSCOMPILING)
-	set(IMPORT_EXECUTABLES "IMPORTFILE-NOTFILE" CACHE FILEPATH)
+	set(IMPORT_EXECUTABLES "IMPORTFILE-NOTFILE" CACHE FILEPATH "Point it to the export file from a native build")
 	include(${IMPORT_EXECUTABLES})
 else ()
 	add_executable(mimegen
@@ -22,6 +22,5 @@ else ()
 		bin2hex.c
 	)
 
-	export(TARGETS mimegen FILE ${CMAKE_BINARY_DIR}/ImportExecutables.cmake)
-	export(TARGETS bin2hex FILE ${CMAKE_BINARY_DIR}/ImportExecutables.cmake)
+	export(TARGETS mimegen bin2hex FILE ${CMAKE_BINARY_DIR}/ImportExecutables.cmake)
 endif ()

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,3 +1,8 @@
+if (CMAKE_CROSSCOMPILING)
+	set(IMPORT_EXECUTABLES "IMPORTFILE-NOTFILE" CACHE FILEPATH "Point it to the export file from a native build")
+	include(${IMPORT_EXECUTABLES})
+endif ()
+
 set(SOURCES
 	base64.c
 	hash.c
@@ -64,7 +69,7 @@ set_target_properties(lwan-shared PROPERTIES
 # Build mimegen
 add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/mime-types.h
-        COMMAND ${CMAKE_BINARY_DIR}/src/bin/tools/mimegen
+        COMMAND mimegen
                 ${CMAKE_SOURCE_DIR}/src/bin/tools/mime.types >
                 ${CMAKE_BINARY_DIR}/mime-types.h
         DEPENDS ${CMAKE_SOURCE_DIR}/src/bin/tools/mime.types mimegen
@@ -77,7 +82,7 @@ add_dependencies(lwan-static generate_mime_types_table)
 
 add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/auto-index-icons.h
-        COMMAND ${CMAKE_BINARY_DIR}/src/bin/tools/bin2hex
+        COMMAND bin2hex
                 ${CMAKE_SOURCE_DIR}/wwwroot/icons/back.gif back_gif
                 ${CMAKE_SOURCE_DIR}/wwwroot/icons/file.gif file_gif
                 ${CMAKE_SOURCE_DIR}/wwwroot/icons/folder.gif

--- a/src/lib/hash.c
+++ b/src/lib/hash.c
@@ -26,7 +26,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#ifndef __CYGWIN__
 #include <sys/syscall.h>
+#endif
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/src/lib/hash.c
+++ b/src/lib/hash.c
@@ -26,9 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#ifndef __CYGWIN__
 #include <sys/syscall.h>
-#endif
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/src/lib/missing.c
+++ b/src/lib/missing.c
@@ -311,7 +311,7 @@ epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout)
 }
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__CYGWIN__)
 #if defined(HAS_GETAUXVAL)
 #include <sys/auxv.h>
 #endif

--- a/src/lib/missing/sys/syscall.h
+++ b/src/lib/missing/sys/syscall.h
@@ -1,0 +1,22 @@
+/*
+ * lwan - simple web server
+ * Copyright (c) 2012 Leandro A. F. Pereira <leandro@hardinfo.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef __CYGWIN__
+#include_next <sys/syscall.h>
+#endif


### PR DESCRIPTION
Encountered a few build issues while using lwan as a test case for a cygwin-hosted x86_64-linux-gnu cross-compiler I'd just built.

* Without the docstring, CMake (at least 3.6.2) sees the ``set(IMPORT_EXECUTABLES "IMPORTFILE-NOTFILE" CACHE FILEPATH)`` as invalid.
* CMake >= 2.6 is capable of resolving mimegen and bin2hex to their corresponding targets. Changed it from the explicit path as a cross compile is likely to happen in a different binary dir.
* The above behavior doesn't seem to apply to imported targets unless explicitly including the `IMPORT_EXECUTABLES` file from the file referencing them.
* Minor tweaks to allow a Cygwin native build for the two generator executables.

There was one other native compilation issue related to the usage of: ``-Wl,-z,now -Wl,-z,relro`` when linking the generator executables. (which Cygwin's ld doesn't recognize and won't ignore) Seemed like a pain to try to resolve, so I just hand-edited the generated link.txt files accordingly. (the [official solution](http://www.cygwin.com/ml/cygwin/2010-01/msg00719.html))
