### PR TITLE
Macos compile

### DIFF
--- a/src/bin/testrunner/main.c
+++ b/src/bin/testrunner/main.c
@@ -220,7 +220,7 @@ LWAN_HANDLER(sleep)
         diff_ms = (t2.tv_sec - t1.tv_sec) * 1000;
         diff_ms += (t2.tv_nsec - t1.tv_nsec) / 1000000;
 
-        lwan_strbuf_printf(response->buffer, "Returned from sleep. diff_ms = %ld", diff_ms);
+        lwan_strbuf_printf(response->buffer, "Returned from sleep. diff_ms = %lld", diff_ms);
     } else {
         lwan_strbuf_set_static(response->buffer, "Did not sleep", 0);
     }

--- a/src/lib/queue.c
+++ b/src/lib/queue.c
@@ -61,14 +61,10 @@ spsc_queue_init(struct spsc_queue *q, size_t size)
         return -EINVAL;
 
     size = lwan_nextpow2(size);
-    #ifdef __APPLE__
-    ret = posix_memalign(q->buffer, sizeof(void *), (1 + size) * sizeof(void *));
+    ret = posix_memalign((void **)&q->buffer, sizeof(void *), (1 + size) * sizeof(void *));
     if (ret < 0) {
     	return -errno;
     }
-    #elif
-    q->buffer = memalign(sizeof(void *), (1 + size) * sizeof(void *));
-    #endif
 
     if (!q->buffer)
         return -errno;

--- a/src/lib/queue.c
+++ b/src/lib/queue.c
@@ -6,7 +6,6 @@
  * [1] https://github.com/mstump/queues/blob/master/include/spsc-bounded-queue.hpp
  */
 
-#include <malloc.h>
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -57,11 +56,20 @@
 int
 spsc_queue_init(struct spsc_queue *q, size_t size)
 {
+    int ret;
     if (size == 0)
         return -EINVAL;
 
     size = lwan_nextpow2(size);
+    #ifdef __APPLE__
+    ret = posix_memalign(q->buffer, sizeof(void *), (1 + size) * sizeof(void *));
+    if (ret < 0) {
+    	return -errno;
+    }
+    #elif
     q->buffer = memalign(sizeof(void *), (1 + size) * sizeof(void *));
+    #endif
+
     if (!q->buffer)
         return -errno;
 


### PR DESCRIPTION
Fixed old malloc and memalign issues to compile on mac os high sierra + xcode. Still the binary format looks weird and can't execute the testsuite and won't pass file/lipo as a valid Mach O binary.

<img width="637" alt="screenshot 2018-07-25 21 13 52" src="https://user-images.githubusercontent.com/38321/43234199-16ef0d9e-9051-11e8-9a13-843f6ebab9f7.png">
