### PR TITLE
expose some needed symbols for template authoring

### DIFF
--- a/src/lib/liblwan.sym
+++ b/src/lib/liblwan.sym
@@ -75,6 +75,15 @@ global:
     lwan_strbuf_set;
     lwan_strbuf_set_static;
 
+    lwan_append_int_to_strbuf;
+    lwan_append_double_to_strbuf;
+    lwan_append_str_to_strbuf;
+    lwan_append_str_escaped_to_strbuf;
+
+    lwan_tpl_int_is_empty;
+    lwan_tpl_double_is_empty;
+    lwan_tpl_str_is_empty;
+
 local:
     *;
 };


### PR DESCRIPTION
It looks like, at least, these 7 symbols need to be exposed in order to author some basic templates (when using ``lwan`` as a dynamic library).

There may be more needed, but I know I need at least these for now.