### PR TITLE
include stddef and stdbool for this header

### DIFF
--- a/src/lib/queue.h
+++ b/src/lib/queue.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdbool.h>
+
 struct spsc_queue {
     size_t size;
     size_t mask;


### PR DESCRIPTION
This is a minor thing; but, if this header is ever used without ``stddef.h`` or ``stdbool.h`` being included, it will throw compile errors.