### PR TITLE
Retry/Complete sendfile when incomplete for large files.

### DIFF
--- a/src/lib/lwan-io-wrappers.c
+++ b/src/lib/lwan-io-wrappers.c
@@ -230,6 +230,7 @@ lwan_sendfile(struct lwan_request *request, int in_fd, off_t offset, size_t coun
 
         chunk_size = min_size(to_be_written, 1<<19);
         lwan_readahead_queue(in_fd, offset, chunk_size);
+        request->conn->flags |= CONN_FLIP_FLAGS;
         coro_yield(request->conn->coro, CONN_CORO_MAY_RESUME);
     }
 }


### PR DESCRIPTION
I ran into an issue with lwan when requesting large static files (e.g. 1 MB). For large files `sendfile` will be used to directly copy from the file to the socket. However, what I see happening is that in `lwan_sendfile` it is correctly determined that more bytes need to be written. At this point, `lwan_sendfile` will yield: https://github.com/lpereira/lwan/blob/9b5b3597f1dbf5ba37fb6f5b4a5d10cda3c752eb/src/lib/lwan-io-wrappers.c#L233

Execution continues in `resume_coro_if_needed`. Since 0318fc5 the epoll event flags are only updated if the `CONN_FLIP_FLAGS` connection flag is set. See https://github.com/lpereira/lwan/blob/9b5b3597f1dbf5ba37fb6f5b4a5d10cda3c752eb/src/lib/lwan-thread.c#L168

However, because of this `epoll_pwait` in `thread_io_loop` is called with the `EPOLLIN` and not the `EPOLLOUT` event flag. See
https://github.com/lpereira/lwan/blob/9b5b3597f1dbf5ba37fb6f5b4a5d10cda3c752eb/src/lib/lwan-thread.c#L334

If there are no (other) events, it will time out at some point. After some time, the sendfile coroutine will also time out and be freed. The large file request is never completed.


This pull request fixes this by making sure we set the `EPOLLOUT` event flag before we yield in `lwan_sendfile` if there are bytes to be written. There might be a more appropriate fix for this though?