### PR TITLE
Add necessary header for OpenBSD

### DIFF
--- a/src/lib/lwan-thread.c
+++ b/src/lib/lwan-thread.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/epoll.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #if defined(HAVE_EVENTFD)


### PR DESCRIPTION
Otherwise, you will get "error: use of undeclared identifier 'SHUT_RDWR'" on OpenBSD 6.4