### PR TITLE
Rewrite example: optional forward slash between rewrite base and pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,11 +415,11 @@ example, where two patterns are specified:
 ```
 rewrite /some/base/endpoint {
     pattern posts/(%d+) {
-        # Matches /some/base/endpointposts/2600
+        # Matches /some/base/endpointposts/2600 and /some/base/endpoint/posts/2600
         rewrite_as = /cms/view-post?id=%1
     }
     pattern imgur/(%a+)/(%g+) {
-        # Matches /some/base/endpointimgur/gif/mpT94Ld
+        # Matches /some/base/endpointimgur/gif/mpT94Ld and /some/base/endpoint/imgur/gif/mpT94Ld
         redirect_to = https://i.imgur.com/%2.%1
     }
 }


### PR DESCRIPTION
I found it a little surprising that the comment in the example mentions (only) `/some/base/endpointimgur/mp4/4kOZNYX` (no forward slash between "endpoint" and "imgur") whereas the text below talks (only) about `/some/base/endpoint/imgur/mp4/4kOZNYX` (with forward slash between "endpoint" and "imgur"). Both do in fact work, so I think it would be clearer if the example simply listed both.