### PR TITLE
(#261) Implement low-cost global-headers

### DIFF
--- a/src/bin/testrunner/testrunner.conf
+++ b/src/bin/testrunner/testrunner.conf
@@ -125,3 +125,7 @@ listener *:8080 {
             cache for = ${CACHE_FOR:5}
     }
 }
+headers {
+    server = lwan/testrunner
+    x-global-header = present
+}

--- a/src/lib/lwan-response.c
+++ b/src/lib/lwan-response.c
@@ -354,9 +354,12 @@ size_t lwan_prepare_response_header_full(
             "\r\nAccess-Control-Allow-Headers: Origin, Accept, Content-Type");
     }
 
-    APPEND_CONSTANT("\r\nServer: lwan\r\n\r\n\0");
+    assert(request->global_response_headers);
+    assert(request->global_response_headers->buffer);
+    assert(request->global_response_headers->used);
+    APPEND_STRING_LEN(request->global_response_headers->buffer, request->global_response_headers->used);
 
-    return (size_t)(p_headers - headers - 1);
+    return (size_t)(p_headers - headers);
 }
 
 #undef APPEND_CHAR

--- a/src/lib/lwan-thread.c
+++ b/src/lib/lwan-thread.c
@@ -117,6 +117,7 @@ __attribute__((noreturn)) static int process_request_coro(struct coro *coro,
 
     while (true) {
         struct lwan_request request = {.conn = conn,
+                                       .global_response_headers = &lwan->headers,
                                        .fd = fd,
                                        .response = {.buffer = &strbuf},
                                        .flags = flags,

--- a/src/lib/lwan.h
+++ b/src/lib/lwan.h
@@ -377,6 +377,7 @@ struct lwan_request {
     struct lwan_value url;
     struct lwan_value original_url;
     struct lwan_connection *conn;
+    const struct lwan_strbuf *const global_response_headers;
     struct lwan_proxy *proxy;
 
     struct timeout timeout;
@@ -457,6 +458,7 @@ struct lwan_straitjacket {
 struct lwan_config {
     /* Field will be overridden during initialization. */
     enum lwan_request_flags request_flags;
+    struct lwan_key_value *global_headers;
 
     char *listener;
     char *error_template;
@@ -478,6 +480,7 @@ struct lwan_config {
 struct lwan {
     struct lwan_trie url_map_trie;
     struct lwan_connection *conns;
+    struct lwan_strbuf headers;
 
     struct {
         pthread_barrier_t barrier;

--- a/src/scripts/testsuite.py
+++ b/src/scripts/testsuite.py
@@ -423,7 +423,7 @@ class TestFileServing(LwanTest):
   def test_has_lwan_server_header(self):
     r = requests.get('http://127.0.0.1:8080/100.html')
     self.assertTrue('server' in r.headers)
-    self.assertEqual(r.headers['server'], 'lwan')
+    self.assertEqual(r.headers['server'], 'lwan/testrunner')
 
 
   def test_directory_without_trailing_slash_redirects(self):
@@ -695,6 +695,12 @@ class TestHelloWorld(LwanTest):
     self.assertTrue('\n\nCookies\n' in r.text)
     for k, v in list(c.items()):
       self.assertTrue('Key = "%s"; Value = "%s"\n' % (k, v) in r.text)
+
+  def test_global_headers_are_present(self):
+    r = requests.get('http://127.0.0.1:8080/hello')
+
+    self.assertTrue('x-global-header' in r.headers)
+    self.assertEqual(r.headers['x-global-header'], 'present')
 
   def test_head_request_hello(self):
     r = requests.head('http://127.0.0.1:8080/hello',


### PR DESCRIPTION
Includes:

- Defaulting global headers to "Server: lwan"
- Allowing specification of a key-value set for headers in config struct
- No added memory leaks (according to ``valgrind``)
- Basic configuration-file support for the ``headers`` section
    - Specifying a header section in a config file ignores global_headers member of the config struct
    - Does not allow disabling the Server header
- Closes #261 