### PR TITLE
Add struct casting to LWAN_ARRAY_STATIC_INIT

### DIFF
--- a/src/lib/lwan-array.h
+++ b/src/lib/lwan-array.h
@@ -103,7 +103,7 @@ struct lwan_array *coro_lwan_array_new(struct coro *coro, bool inline_first);
         __attribute__((nonnull(1))) static inline void array_type_##_init(     \
             struct array_type_ *array)                                         \
     {                                                                          \
-        array->base = LWAN_ARRAY_STATIC_INIT;                                  \
+        array->base = (struct lwan_array) LWAN_ARRAY_STATIC_INIT;              \
     }                                                                          \
     __attribute__((unused)) static inline int array_type_##_reset(             \
         struct array_type_ *array)                                             \

--- a/src/lib/lwan.c
+++ b/src/lib/lwan.c
@@ -186,7 +186,7 @@ static void build_response_headers(struct lwan *l,
 static void parse_global_headers(struct config *c,
                                  struct lwan *lwan)
 {
-    struct lwan_key_value_array hdrs = LWAN_ARRAY_STATIC_INIT;
+    struct lwan_key_value_array hdrs = (struct lwan_key_value_array) LWAN_ARRAY_STATIC_INIT;
     const struct config_line *l;
     struct lwan_key_value *kv;
 


### PR DESCRIPTION
Without the struct castings, the `make` build is failing with the following error:
![image](https://user-images.githubusercontent.com/20739674/84781881-d1871180-b000-11ea-9abe-ff07ee1e28fe.png)
