### PR TITLE
docs: fix simple typo, wich -> which

### DIFF
--- a/src/lib/list.h
+++ b/src/lib/list.h
@@ -608,7 +608,7 @@ static inline void list_prepend_list(struct list_head *to,
 /**
  * list_for_each_off - iterate through a list of memory regions.
  * @h: the list_head
- * @i: the pointer to a memory region wich contains list node data.
+ * @i: the pointer to a memory region which contains list node data.
  * @off: offset(relative to @i) at which list node data resides.
  *
  * This is a low-level wrapper to iterate @i over the entire list, used to
@@ -644,7 +644,7 @@ static inline void list_prepend_list(struct list_head *to,
  * list_for_each_safe_off - iterate through a list of memory regions, maybe
  * during deletion
  * @h: the list_head
- * @i: the pointer to a memory region wich contains list node data.
+ * @i: the pointer to a memory region which contains list node data.
  * @nxt: the structure containing the list_node
  * @off: offset(relative to @i) at which list node data resides.
  *


### PR DESCRIPTION
There is a small typo in src/lib/list.h.

Should read `which` rather than `wich`.

