### PR TITLE
Add application/wasm Web Assembly mime type

### DIFF
--- a/src/bin/tools/mime.types
+++ b/src/bin/tools/mime.types
@@ -1000,6 +1000,7 @@ application/vnd.zul				zir zirz
 application/vnd.zzazz.deck+xml			zaz
 application/voicexml+xml			vxml
 # application/vq-rtcpxr
+application/wasm				wasm
 # application/watcherinfo+xml
 # application/whoispp-query
 # application/whoispp-response


### PR DESCRIPTION
This adds the application/wasm mime type, which is used to represent compiled Web Assembly files, and registers it with the associated file extension, `.wasm`.

It's not a registered standard mimetype, but it is widely recognized. It's the mimetype listed in the [official WebAssembly conventions document](https://webassembly.github.io/spec/core/binary/conventions.html), and all major browsers recognize it.

My main motivation for this is so that I can use the `WebAssembly.instantiateStreaming` browser API on wasm files served by lwan. This api specifically requires the application/wasm mimetype, otherwise the browser won't instantiate streaming and instead requires loading the wasm file as a binary value before initializing. See the MDN documentation mentioning this requirement: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming#Instantiating_streaming

Hopefully this will be an official mimetype at some point - there's an issue for that here: https://github.com/WebAssembly/spec/issues/573.

However, until then - I saw this file listed both "official" and "widely recognized" mimetypes, and I'm hoping application/wasm falls into the second one.