### PR TITLE
fix: check alignment size of posix_memalign

### DIFF
--- a/src/lib/lwan-private.h
+++ b/src/lib/lwan-private.h
@@ -208,6 +208,7 @@ lwan_aligned_alloc(size_t n, size_t alignment)
     void *ret;
 
     assert((alignment & (alignment - 1)) == 0);
+    assert((alignment % (sizeof(void *)) == 0);
 
     n = (n + alignment - 1) & ~(alignment - 1);
     if (UNLIKELY(posix_memalign(&ret, alignment, n)))


### PR DESCRIPTION
According to documentation of `posix_memalign`:
> Alignment must be a power of two and a multiple of sizeof(void *).

Currently all related code call `lwan_aligned_alloc` with `alignment` set to `64`, but maybe it's safer to check it again in the `lwan_aligned_alloc` function.