### PR TITLE
fix: missing right parenthesis

### DIFF
--- a/src/lib/lwan-private.h
+++ b/src/lib/lwan-private.h
@@ -208,7 +208,7 @@ lwan_aligned_alloc(size_t n, size_t alignment)
     void *ret;
 
     assert((alignment & (alignment - 1)) == 0);
-    assert((alignment % (sizeof(void *)) == 0);
+    assert((alignment % (sizeof(void *))) == 0);
 
     n = (n + alignment - 1) & ~(alignment - 1);
     if (UNLIKELY(posix_memalign(&ret, alignment, n)))


### PR DESCRIPTION
Sorry for being careless, this patch is for fixing PR: #316.
A missing right parenthesis is causing CI build failure.
I have built it in my own environment, I will check the CI status later.

update:
`LGTM analysis: C/C++ ` currently failed because of broken code in master branch, please check and merge back to fix this.
<img width="826" alt="截圖 2021-09-13 上午11 46 10" ### src="https://user-images.githubusercontent.com/7500954/133021074-c3b664c4-a9c3-4185-8d58-9fcfb5c7ecd5.png">
