### PR TITLE
lwan container image

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -1,0 +1,39 @@
+name: Build and publish lwan container images
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: latest ${{ github.event.release.tag_name }}
+          dockerfiles: |
+            ./Containerfile
+      
+      - name: Push to ghcr.io
+        id: push-to-ghcr
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,15 @@
+FROM docker.io/library/alpine:3.14.2 AS build
+RUN apk add --no-cache gcc make musl-dev cmake pkgconfig linux-headers \
+      luajit-dev sqlite-dev zlib-dev brotli-dev zstd-dev
+COPY . /lwan
+WORKDIR /lwan/build
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release
+RUN make -j
+
+FROM docker.io/library/alpine:3.14.2
+RUN apk add --no-cache luajit sqlite zlib brotli zstd-dev
+COPY --from=build /lwan/build/src/bin/lwan/lwan .
+COPY --from=build /lwan/lwan.conf .
+EXPOSE 8080
+VOLUME /wwwroot
+ENTRYPOINT ["/lwan"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+Containerfile

--- a/README.md
+++ b/README.md
@@ -635,6 +635,35 @@ section with a `basic` parameter, and set one of its options.
 | `realm` | `str` | `Lwan` | Realm for authorization. This is usually shown in the user/password UI in browsers |
 | `password_file` | `str` | `NULL` | Path for a file containing username and passwords (in clear text).  The file format is the same as the configuration file format used by Lwan |
 
+Container Images
+----------------
+lwan container images are available at [ghcr.io/lperiera/lwan](https://ghcr.io/lperiera/lwan).
+Container runtimes like [docker](https://docker.io) or [podman](https://podman.io) may be used to build and run lwan in a container.
+
+
+### Pull lwan images from GHCR
+Container images are tagged with release version numbers, so a specific version of lwan can be pulled.
+
+    # latest version
+    docker pull ghcr.io/lperiera/lwan:latest
+    # pull a specific version
+    docker pull ghcr.io/lperiera/lwan:v0.3
+    
+### Build images locally
+Clone the repository and use Containerfile (Dockerfile) to build lwan with all optional dependencies enabled.
+
+    podman build -t lwan .
+    
+### Run your image
+The image expects to find static content at /wwwroot, so a volume containing your content can be mounted.
+
+    docker run --rm -p 8080:8080 -v ./www:/wwwroot lwan
+    
+To bring your own own lwan.conf, simply mount it at /lwan.conf.
+
+    podman run --rm -p 8080:8080 -v ./lwan.conf:/lwan.conf lwan
+
+
 Hacking
 -------
 


### PR DESCRIPTION
This change will build and push the lpereira/lwan container image to GitHub Container Registry at ghcr.io/lpereira/lwan. It will build and push an image each time a new release is published.

Currently only an amd64 container image is built and published. Once buildah build github action learns how to do manifests, I will convert this into a multi-arch build.

Also included is a Containerfile (Dockerfile) for building the image.