### PR TITLE
Re-expose lwan_straitjacket_enforce()

### DIFF
--- a/src/lib/liblwan.sym
+++ b/src/lib/liblwan.sym
@@ -74,7 +74,7 @@ global:
     lwan_request_await_*;
     lwan_request_async_*;
 
-    lwan_straitjacket_enforce_*;
+    lwan_straitjacket_enforce*;
 
 local:
     *;


### PR DESCRIPTION
7d4a98f re-exposed straitjackets to the C API; however, the pattern
added to /src/lib/liblwan.sym accidentally excluded
`lwan_straitjacket_enforce()`.

Closes #337

Signed-off-by: Sam Stuewe <samuel.stuewe@gmail.com>