### PR TITLE
Define MSG_FASTOPEN

### DIFF
--- a/src/bin/tools/weighttp.c
+++ b/src/bin/tools/weighttp.c
@@ -46,6 +46,9 @@
 #include <netinet/in.h>
 #include <sys/un.h>
 
+#ifndef MSG_FASTOPEN
+#define MSG_FASTOPEN 0
+#endif
 #ifndef MSG_DONTWAIT
 #define MSG_DONTWAIT 0
 #endif


### PR DESCRIPTION
For some reason, this gets picked up on FreeBSD and not Linux.

Also, I'm not 100% sure `MSG_FASTOPEN` should be defined as `0` by default.