### PR TITLE
Fix condition check for character range validation

### DIFF
--- a/src/lib/lwan-config.c
+++ b/src/lib/lwan-config.c
@@ -165,7 +165,7 @@ static bool _parse_i64(const char *s, int64_t *out)
         negative = true;
     }
 
-    if (UNLIKELY(*s < '0' && *s > '9'))
+    if (UNLIKELY(*s < '0' || *s > '9'))
         return false;
 
     goto elide_mult_for_first_iter;


### PR DESCRIPTION
Fixes #377 

This changes the check to `||`, so empty values and non-digit first bytes are rejected before the parser consumes them.